### PR TITLE
Use MoveGuard for path traversal and add rescuer-following viewport

### DIFF
--- a/src/agent/AgentController.java
+++ b/src/agent/AgentController.java
@@ -1,8 +1,10 @@
 package agent;
 
+import map.CityMap;
 import map.Hospital;
 import strategy.IPathFinder;
 import strategy.IAgentDecision;
+import util.MoveGuard;
 import util.Position;
 import victim.Injured;
 
@@ -17,8 +19,10 @@ public class AgentController {
 
     private final IPathFinder pathFinder;
     private final IAgentDecision decisionLogic;
+    private final CityMap map;
 
-    public AgentController(IPathFinder pathFinder, IAgentDecision decisionLogic) {
+    public AgentController(CityMap map, IPathFinder pathFinder, IAgentDecision decisionLogic) {
+        this.map = map;
         this.pathFinder = pathFinder;
         this.decisionLogic = decisionLogic;
     }
@@ -29,25 +33,45 @@ public class AgentController {
             Injured target = decisionLogic.selectVictim(rescuer, candidates);
             if (target != null) {
                 List<Position> pathToVictim = pathFinder.findPath(rescuer.getPosition(), target.getPosition());
-                moveAlongPath(rescuer, pathToVictim);
-                rescuer.pickUp(target);
+                if (moveAlongPath(rescuer, pathToVictim)) {
+                    rescuer.pickUp(target);
+                }
             }
         }
 
         if (rescuer.isCarryingVictim()) {
             Hospital nearestHospital = findNearestHospital(rescuer.getPosition(), hospitals);
             List<Position> pathToHospital = pathFinder.findPath(rescuer.getPosition(), nearestHospital.getPosition());
-            moveAlongPath(rescuer, pathToHospital);
-            rescuer.dropVictim();
+            if (moveAlongPath(rescuer, pathToHospital)) {
+                rescuer.dropVictim();
+            }
         }
     }
 
     // حرکت نجات‌دهنده در طول مسیر مشخص شده
-    private void moveAlongPath(Rescuer rescuer, List<Position> path) {
+    private boolean moveAlongPath(Rescuer rescuer, List<Position> path) {
+        if (rescuer == null || path == null || path.isEmpty()) return false;
+        Position current = rescuer.getPosition();
         for (Position step : path) {
-            rescuer.setPosition(step);
-            // اینجا می‌تونی delay، animation یا repaint ui بزاری
+            if (step.equals(current)) continue;
+            int dir = determineDirection(current, step);
+            if (!MoveGuard.tryMoveTo(map, rescuer, step.getX(), step.getY(), dir)) {
+                return false;
+            }
+            current = step;
         }
+        return true;
+    }
+
+    // تعیین جهت بر اساس دلتا بین دو موقعیت (0=پایین،1=چپ،2=راست،3=بالا)
+    private int determineDirection(Position from, Position to) {
+        int dx = to.getX() - from.getX();
+        int dy = to.getY() - from.getY();
+        if (dx == 1) return 2;      // راست
+        if (dx == -1) return 1;     // چپ
+        if (dy == 1) return 0;      // پایین
+        if (dy == -1) return 3;     // بالا
+        return 0;                   // پیش‌فرض
     }
 
     // پیدا کردن نزدیک‌ترین بیمارستان به موقعیت فعلی

--- a/src/agent/Rescuer.java
+++ b/src/agent/Rescuer.java
@@ -90,6 +90,15 @@ public class Rescuer {
             }
         }
 
+        // ساخت فریم‌های جهت چپ با وارونه‌سازی افقی فریم‌های راست
+        BufferedImage[] leftRow = new BufferedImage[COLS];
+        for (int c = 0; c < COLS; c++) {
+            if (frames[2][c] != null) {
+                leftRow[c] = flipHorizontal(frames[2][c]);
+            }
+        }
+        frames[1] = leftRow;
+
         // اگر ردیف UP در شیت وجود ندارد، از ردیف DOWN کپی کن
         if (frames[3] == null || frames[3][0] == null) {
             BufferedImage[] upRow = new BufferedImage[COLS];
@@ -235,6 +244,18 @@ public class Rescuer {
         g2.drawImage(src, 0, 0, w, h, null);
         g2.dispose();
         return dst;
+    }
+
+    /** وارونه‌سازی افقی تصویر برای ساخت فریم‌های جهت چپ از راست */
+    private static BufferedImage flipHorizontal(BufferedImage src) {
+        if (src == null) return null;
+        int w = src.getWidth();
+        int h = src.getHeight();
+        BufferedImage out = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = out.createGraphics();
+        g.drawImage(src, 0, 0, w, h, w, 0, 0, h, null);
+        g.dispose();
+        return out;
     }
 
     public void setDirection(int dir) { this.direction = clamp(dir, 0, 3); }

--- a/src/controller/RescueCoordinator.java
+++ b/src/controller/RescueCoordinator.java
@@ -2,6 +2,7 @@ package controller;
 
 import agent.AgentController;
 import agent.AgentManager;
+import map.CityMap;
 import map.Hospital;
 import strategy.IAgentDecision;
 import strategy.IPathFinder;
@@ -25,13 +26,14 @@ public class RescueCoordinator {
     public RescueCoordinator(AgentManager agentManager,
                              VictimManager victimManager,
                              List<Hospital> hospitals,
+                             CityMap map,
                              IPathFinder pathFinder,
                              IAgentDecision decisionLogic) {
 
         this.agentManager = agentManager;
         this.victimManager = victimManager;
         this.hospitals = hospitals;
-        this.agentController = new AgentController(pathFinder, decisionLogic);
+        this.agentController = new AgentController(map, pathFinder, decisionLogic);
     }
 
     // اجرای یک دور عملیات نجات برای همه نجات‌دهنده‌ها

--- a/src/ui/GamePanel.java
+++ b/src/ui/GamePanel.java
@@ -33,6 +33,12 @@ public class GamePanel extends JPanel {
     private double rescuerScale = 2.0;     // بزرگ‌نمایی فقط برای Rescuer
     private boolean debugWalkable = false; // اورلی دیباگ: سبز/قرمز (walkable/occupied)
 
+    // ---- Viewport ----
+    private int viewX = 0;                 // مختصات تایل بالا-چپ ویوپورت
+    private int viewY = 0;
+    private int viewWidth;                 // عرض ویوپورت بر حسب تعداد تایل
+    private int viewHeight;                // ارتفاع ویوپورت بر حسب تعداد تایل
+
     // ---- سازنده ----
     public GamePanel(CityMap cityMap, List<Rescuer> rescuers, List<Injured> victims) {
         this.cityMap = cityMap;
@@ -40,10 +46,15 @@ public class GamePanel extends JPanel {
         this.victims = victims;
 
         if (cityMap != null) {
-            setPreferredSize(new Dimension(cityMap.getWidth() * tileSize,
-                    cityMap.getHeight() * tileSize));
+            this.viewWidth = Math.max(1, cityMap.getWidth() / 2);
+            this.viewHeight = Math.max(1, cityMap.getHeight() / 2);
+            setPreferredSize(new Dimension(viewWidth * tileSize,
+                    viewHeight * tileSize));
         } else {
-            setPreferredSize(new Dimension(800, 600));
+            this.viewWidth = 25; // مقادیر پیش‌فرض اگر نقشه‌ای موجود نباشد
+            this.viewHeight = 19;
+            setPreferredSize(new Dimension(viewWidth * tileSize,
+                    viewHeight * tileSize));
         }
 
         setFocusable(true);
@@ -60,35 +71,64 @@ public class GamePanel extends JPanel {
         g.setColor(new Color(200, 200, 200));
         g.fillRect(0, 0, getWidth(), getHeight());
 
-        if (cityMap != null) {
-            drawMap(g);
-        }
+        if (cityMap == null) return;
+
+        updateViewport();
+
+        Graphics2D gWorld = (Graphics2D) g.create();
+        gWorld.translate(-viewX * tileSize, -viewY * tileSize);
+
+        drawMap(gWorld);
 
         if (victims != null) {
-            drawVictims(g);
+            drawVictims(gWorld);
         }
 
         if (rescuers != null) {
-            Graphics2D g2 = (Graphics2D) g.create();
+            Graphics2D g2 = (Graphics2D) gWorld.create();
             g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
             g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
             drawRescuers(g2);
             g2.dispose();
         }
 
-        if (debugWalkable && cityMap != null) {
-            drawWalkableOverlay(g);
+        if (debugWalkable) {
+            drawWalkableOverlay(gWorld);
         }
 
-        if (drawGrid && cityMap != null) {
-            drawGridLines(g);
+        if (drawGrid) {
+            drawGridLines(gWorld);
         }
+
+        gWorld.dispose();
     }
 
     // ---------------------- متدهای رندر ----------------------
+    private void updateViewport() {
+        if (cityMap == null || rescuers == null || rescuers.isEmpty()) return;
+        Rescuer r = rescuers.get(0);
+        if (r == null || r.getPosition() == null) return;
+
+        int centerX = r.getPosition().getX();
+        int centerY = r.getPosition().getY();
+        viewX = centerX - viewWidth / 2;
+        viewY = centerY - viewHeight / 2;
+
+        if (viewX < 0) viewX = 0;
+        if (viewY < 0) viewY = 0;
+        int maxX = cityMap.getWidth() - viewWidth;
+        int maxY = cityMap.getHeight() - viewHeight;
+        if (viewX > maxX) viewX = maxX;
+        if (viewY > maxY) viewY = maxY;
+    }
+
     private void drawMap(Graphics g) {
-        for (int y = 0; y < cityMap.getHeight(); y++) {
-            for (int x = 0; x < cityMap.getWidth(); x++) {
+        int startY = viewY;
+        int endY = Math.min(cityMap.getHeight(), viewY + viewHeight);
+        int startX = viewX;
+        int endX = Math.min(cityMap.getWidth(), viewX + viewWidth);
+        for (int y = startY; y < endY; y++) {
+            for (int x = startX; x < endX; x++) {
                 Cell cell = cityMap.getCell(x, y);
                 if (cell == null) continue;
 
@@ -109,6 +149,8 @@ public class GamePanel extends JPanel {
 
             Position p = inj.getPosition();
             if (p == null) continue;
+            if (p.getX() < viewX || p.getX() >= viewX + viewWidth ||
+                    p.getY() < viewY || p.getY() >= viewY + viewHeight) continue;
 
             Color col;
             InjurySeverity sev = inj.getSeverity();
@@ -129,6 +171,9 @@ public class GamePanel extends JPanel {
             if (r == null || r.getPosition() == null) continue;
 
             Position pos = r.getPosition();
+            if (pos.getX() < viewX || pos.getX() >= viewX + viewWidth ||
+                    pos.getY() < viewY || pos.getY() >= viewY + viewHeight) continue;
+
             int baseX = pos.getX() * tileSize;
             int baseY = pos.getY() * tileSize;
             int size = (int) Math.round(tileSize * rescuerScale);
@@ -150,8 +195,12 @@ public class GamePanel extends JPanel {
     private void drawWalkableOverlay(Graphics g) {
         Graphics2D gg = (Graphics2D) g.create();
         gg.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.25f));
-        for (int y = 0; y < cityMap.getHeight(); y++) {
-            for (int x = 0; x < cityMap.getWidth(); x++) {
+        int startY = viewY;
+        int endY = Math.min(cityMap.getHeight(), viewY + viewHeight);
+        int startX = viewX;
+        int endX = Math.min(cityMap.getWidth(), viewX + viewWidth);
+        for (int y = startY; y < endY; y++) {
+            for (int x = startX; x < endX; x++) {
                 Cell c = cityMap.getCell(x, y);
                 if (c == null) continue;
                 int px = x * tileSize;
@@ -166,11 +215,13 @@ public class GamePanel extends JPanel {
 
     private void drawGridLines(Graphics g) {
         g.setColor(new Color(0, 0, 0, 40));
-        int w = (cityMap != null ? cityMap.getWidth() * tileSize : getWidth());
-        int h = (cityMap != null ? cityMap.getHeight() * tileSize : getHeight());
+        int startX = viewX * tileSize;
+        int endX = (viewX + viewWidth) * tileSize;
+        int startY = viewY * tileSize;
+        int endY = (viewY + viewHeight) * tileSize;
 
-        for (int x = 0; x <= w; x += tileSize) g.drawLine(x, 0, x, h);
-        for (int y = 0; y <= h; y += tileSize) g.drawLine(0, y, w, y);
+        for (int x = startX; x <= endX; x += tileSize) g.drawLine(x, startY, x, endY);
+        for (int y = startY; y <= endY; y += tileSize) g.drawLine(startX, y, endX, y);
     }
 
     // ---------------------- Setter / Update ----------------------
@@ -179,9 +230,12 @@ public class GamePanel extends JPanel {
         this.rescuers = rescuers;
         this.victims = victims;
         if (cityMap != null) {
-            setPreferredSize(new Dimension(cityMap.getWidth() * tileSize,
-                    cityMap.getHeight() * tileSize));
+            this.viewWidth = Math.max(1, cityMap.getWidth() / 2);
+            this.viewHeight = Math.max(1, cityMap.getHeight() / 2);
+            setPreferredSize(new Dimension(viewWidth * tileSize,
+                    viewHeight * tileSize));
         }
+        updateViewport();
         revalidate();
         repaint();
     }
@@ -190,8 +244,8 @@ public class GamePanel extends JPanel {
         if (tileSize <= 0) return;
         this.tileSize = tileSize;
         if (cityMap != null) {
-            setPreferredSize(new Dimension(cityMap.getWidth() * tileSize,
-                    cityMap.getHeight() * tileSize));
+            setPreferredSize(new Dimension(viewWidth * tileSize,
+                    viewHeight * tileSize));
         }
         revalidate();
         repaint();
@@ -217,15 +271,19 @@ public class GamePanel extends JPanel {
     public void setMap(CityMap cityMap) {
         this.cityMap = cityMap;
         if (cityMap != null) {
-            setPreferredSize(new Dimension(cityMap.getWidth() * tileSize,
-                    cityMap.getHeight() * tileSize));
+            this.viewWidth = Math.max(1, cityMap.getWidth() / 2);
+            this.viewHeight = Math.max(1, cityMap.getHeight() / 2);
+            setPreferredSize(new Dimension(viewWidth * tileSize,
+                    viewHeight * tileSize));
         }
+        updateViewport();
         revalidate();
         repaint();
     }
 
     public void setRescuers(List<Rescuer> rescuers) {
         this.rescuers = rescuers;
+        updateViewport();
         repaint();
     }
 


### PR DESCRIPTION
## Summary
- Prevent rescuers from teleporting through obstacles by routing all path steps through `MoveGuard`
- Display only a quarter of the map and keep the viewport synced with the rescuer's position
- Mirror right-facing frames so the rescuer looks left when moving left

## Testing
- `find src -name "*.java" > sources.txt`
- `javac @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68b1a3d96294832b9618a758581b6d77