### PR TITLE
Handle movement without TMX walkable properties

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -27,7 +27,8 @@ public class Main {
                 try {
                     // 1) Load map + collision
                     map = MapLoader.loadTMX("assets/maps/rescue_city.tmx");
-                    collisionMap = CollisionMap.fromTMX("assets/maps/rescue_city.tmx");
+                    collisionMap = CollisionMap.fromMask("assets/maps/Road.png",
+                            map.getTileWidth(), map.getTileHeight());
                     map.setCollisionMap(collisionMap);
 
                     // 2) Spawn rescuer at nearest road (bottom-right search)
@@ -108,14 +109,13 @@ public class Main {
             for (int x = map.getWidth() - 1; x >= 0; x--) {
                 Cell c = map.getCell(x, y);
 
-                boolean walkableByMask = (collisionMap != null) && collisionMap.isWalkable(x, y);
-                boolean isRoadCell     = (c != null) && c.getType() == Cell.Type.ROAD;
-                boolean free           = (c == null) || !c.isOccupied();
+                boolean walkable = (collisionMap != null)
+                        ? collisionMap.isWalkable(x, y)
+                        : (c != null && c.getType() == Cell.Type.ROAD);
+                boolean free = (c == null) || !c.isOccupied();
 
-                if ((walkableByMask || isRoadCell) && free) {
-                    // اگر سلول وجود ندارد یا نوعش جاده نیست، یک سلول جاده بساز تا HUD/Renderer هم بداند
+                if (walkable && free) {
                     if (c == null || c.getType() != Cell.Type.ROAD) {
-                        // اگر سازنده‌ی Cell شما امضای دیگری دارد، همین خط را مطابق پروژه‌ات تنظیم کن
                         map.setCell(x, y, new Cell(new Position(x, y), Cell.Type.ROAD));
                     }
                     return new Position(x, y);

--- a/src/map/CityMap.java
+++ b/src/map/CityMap.java
@@ -82,13 +82,16 @@ public class CityMap {
     public boolean isWalkable(int x, int y) {
         if (!isValid(x, y)) return false;
 
-        // اگر CollisionMap موجود باشد، walkable بودن از آن خوانده می‌شود
-        if (collisionMap != null && !collisionMap.isWalkable(x, y)) {
-            return false;
+        Cell c = grid[y][x];
+        if (c == null || c.isOccupied()) return false;
+
+        // اگر CollisionMap وجود دارد و آن سلول را قابل عبور علامت زده باشد، قبول
+        if (collisionMap != null && collisionMap.isWalkable(x, y)) {
+            return true;
         }
 
-        Cell c = grid[y][x];
-        return c != null && !c.isOccupied() && (collisionMap != null || c.isWalkable());
+        // در غیر این صورت، به نوع سلول تکیه می‌کنیم
+        return c.isWalkable();
     }
 
     /** آیا مختصات پیکسلی (px,py) روی تایلِ قابل عبور و غیر اشغال می‌افتد؟ */

--- a/src/map/MapLoader.java
+++ b/src/map/MapLoader.java
@@ -148,7 +148,8 @@ public final class MapLoader {
                 BufferedImage tileImage = owner.getSubImage(gid);
 
                 // نوع سلول از property ها
-                Cell.Type type = Cell.Type.OBSTACLE; // پیش‌فرض
+                // اگر هیچ property تعریف نشده باشد، نوع مشخصی نداریم
+                Cell.Type type = Cell.Type.EMPTY;
                 boolean walkable = false;
 
                 int localId = gid - owner.firstGid;
@@ -175,9 +176,11 @@ public final class MapLoader {
                     }
                 }
 
-                // walkable به‌تنهایی → ROAD
-                if (walkable && type == Cell.Type.OBSTACLE) {
+                // هماهنگ‌سازی نوع سلول با وضعیت walkable
+                if (walkable && type == Cell.Type.EMPTY) {
                     type = Cell.Type.ROAD;
+                } else if (!walkable && type == Cell.Type.ROAD) {
+                    type = Cell.Type.OBSTACLE;
                 }
 
                 // (اختیاری) fallback ساده به‌ازای GID

--- a/src/util/CollisionMap.java
+++ b/src/util/CollisionMap.java
@@ -123,6 +123,34 @@ public class CollisionMap {
         return cm;
     }
 
+    /**
+     * ساخت CollisionMap از ماسک PNG که در آن هر بلوک tileWidth×tileHeight معرف یک تایل است.
+     * پیکسل سفید ⇒ قابل عبور، سیاه ⇒ غیرقابل عبور.
+     */
+    public static CollisionMap fromMask(String maskPath, int tileWidth, int tileHeight) throws IOException {
+        BufferedImage img = ImageIO.read(new File(maskPath));
+        int w = img.getWidth() / tileWidth;
+        int h = img.getHeight() / tileHeight;
+        CollisionMap cm = new CollisionMap(w, h);
+
+        for (int ty = 0; ty < h; ty++) {
+            for (int tx = 0; tx < w; tx++) {
+                int px = tx * tileWidth;
+                int py = ty * tileHeight;
+
+                boolean walk = false;
+                for (int oy = 0; oy < tileHeight && !walk; oy++) {
+                    for (int ox = 0; ox < tileWidth; ox++) {
+                        int rgb = img.getRGB(px + ox, py + oy) & 0xFFFFFF;
+                        if (rgb != 0x000000) { walk = true; break; }
+                    }
+                }
+                cm.walkable[ty][tx] = walk;
+            }
+        }
+        return cm;
+    }
+
     public int getWidth() { return width; }
     public int getHeight() { return height; }
 }

--- a/src/util/MoveGuard.java
+++ b/src/util/MoveGuard.java
@@ -18,10 +18,15 @@ public final class MoveGuard {
 
     private MoveGuard() { }
 
-    /** حرکت به مقصد مطلق (nx,ny) با جهت dir و بررسی CollisionMap. */
-    public static boolean tryMoveTo(CityMap map, CollisionMap collision, Rescuer r, int nx, int ny, int dir) {
-        if (map == null || collision == null || r == null || r.getPosition() == null) return false;
-        if (!map.isValid(nx, ny) || !collision.isWalkable(nx, ny)) return false;
+    /**
+     * حرکت به مقصد مطلق (nx,ny) با جهت dir.
+     * اگر CollisionMap وجود داشته باشد ولی propertyهای مربوطه در فایل TMX تعریف نشده
+     * باشند، با تکیه بر اطلاعات خود Cell تعیین می‌کنیم که سلول قابل عبور است یا نه.
+     */
+    public static boolean tryMoveTo(CityMap map, CollisionMap collision, Rescuer r,
+                                    int nx, int ny, int dir) {
+        if (map == null || r == null || r.getPosition() == null) return false;
+        if (!map.isValid(nx, ny)) return false;
 
         // اگر مقصد همان جای فعلی است: فقط جهت/فریم را آپدیت کن
         if (r.getPosition().getX() == nx && r.getPosition().getY() == ny) {
@@ -31,27 +36,18 @@ public final class MoveGuard {
         }
 
         final Cell dest = map.getCell(nx, ny);
-
-
-
-        if (dest == null || dest.isOccupied()) return false;
-
         if (dest == null) return false;
 
-        // فقط اجازه‌ی حرکت روی سلول‌های جاده یا بیمارستان که خالی باشند
-        Cell.Type type = dest.getType();
-        if ((type != Cell.Type.ROAD && type != Cell.Type.HOSPITAL) || dest.isOccupied()) {
-            return false;
+        // اگر نگاشت برخورد وجود دارد، صرفاً به همان تکیه کن
+        if (collision != null) {
+            if (!collision.isWalkable(nx, ny)) return false;
+        } else {
+            // در نبود CollisionMap باید خود سلول قابل عبور باشد
+            if (!dest.isWalkable()) return false;
         }
 
-        // فقط اجازه‌ی حرکت روی سلول‌های قابل عبور و خالی
-        if (!dest.isWalkable() || dest.isOccupied()) return false;
-
-
-
-        // فقط اجازه‌ی حرکت روی جاده‌های خالی
-        if (dest.getType() != Cell.Type.ROAD || dest.isOccupied()) return false;
-
+        // در هر صورت روی سلول اشغال‌شده اجازه حرکت نده
+        if (dest.isOccupied()) return false;
 
         // آزاد کردن سلول فعلی (اگر معتبر بود)
         int cx = r.getPosition().getX();
@@ -75,8 +71,9 @@ public final class MoveGuard {
     }
 
     /** حرکت نسبی بر اساس دلتا (dx,dy) با جهت dir. */
-    public static boolean tryMoveDelta(CityMap map, CollisionMap collision, Rescuer r, int dx, int dy, int dir) {
-        if (map == null || collision == null || r == null || r.getPosition() == null) return false;
+    public static boolean tryMoveDelta(CityMap map, CollisionMap collision, Rescuer r,
+                                       int dx, int dy, int dir) {
+        if (map == null || r == null || r.getPosition() == null) return false;
         final int nx = r.getPosition().getX() + dx;
         final int ny = r.getPosition().getY() + dy;
         return tryMoveTo(map, collision, r, nx, ny, dir);


### PR DESCRIPTION
## Summary
- Align cell types with walkability when loading TMX maps
- Scan entire mask tiles to mark roads as walkable

## Testing
- `javac -d out @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68b2a665a48c832bb6967c80fa48fa60