### PR TITLE
Restrict movement to TMX-defined roads

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -25,10 +25,9 @@ public class Main {
         SwingUtilities.invokeLater(new Runnable() {
             @Override public void run() {
                 try {
-                    // 1) Load map + collision
+                    // 1) Load map + collision directly from TMX properties
                     map = MapLoader.loadTMX("assets/maps/rescue_city.tmx");
-                    collisionMap = CollisionMap.fromMask("assets/maps/Road.png",
-                            map.getTileWidth(), map.getTileHeight());
+                    collisionMap = CollisionMap.fromTMX("assets/maps/rescue_city.tmx");
                     map.setCollisionMap(collisionMap);
 
                     // 2) Spawn rescuer at nearest road (bottom-right search)

--- a/src/map/MapLoader.java
+++ b/src/map/MapLoader.java
@@ -183,11 +183,8 @@ public final class MapLoader {
                 // هماهنگ‌سازی نوع سلول با وضعیت walkable
                 if (walkable && type == Cell.Type.EMPTY) {
                     type = Cell.Type.ROAD;
-                } else if (!walkable && type == Cell.Type.ROAD) {
-
-                // اگر مشخصاً غیرقابل عبور باشد ولی نوعی تعیین نشده، آن را مانع فرض کن
-                if (!walkable && (type == Cell.Type.ROAD || type == Cell.Type.EMPTY)) {
-
+                } else if (!walkable && (type == Cell.Type.ROAD || type == Cell.Type.EMPTY)) {
+                    // اگر مشخصاً غیرقابل عبور باشد ولی نوعی تعیین نشده، آن را مانع فرض کن
                     type = Cell.Type.OBSTACLE;
                 }
 


### PR DESCRIPTION
## Summary
- Load collision data directly from the TMX map so only tiles marked walkable are traversable
- Align `MapLoader` cell-type synchronization with walkable property

## Testing
- `mkdir -p /tmp/build && find src -name "*.java" | xargs javac -d /tmp/build`


------
https://chatgpt.com/codex/tasks/task_e_68b2e55463e0832bbaa61fbaffab2b1c