### PR TITLE
Restrict movement to TMX-defined roads

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -25,10 +25,9 @@ public class Main {
         SwingUtilities.invokeLater(new Runnable() {
             @Override public void run() {
                 try {
-                    // 1) Load map + collision
+                    // 1) Load map + collision directly from TMX properties
                     map = MapLoader.loadTMX("assets/maps/rescue_city.tmx");
-                    collisionMap = CollisionMap.fromMask("assets/maps/Road.png",
-                            map.getTileWidth(), map.getTileHeight());
+                    collisionMap = CollisionMap.fromTMX("assets/maps/rescue_city.tmx");
                     map.setCollisionMap(collisionMap);
 
                     // 2) Spawn rescuer at nearest road (bottom-right search)

--- a/src/map/Cell.java
+++ b/src/map/Cell.java
@@ -17,7 +17,24 @@ public class Cell {
         OBSTACLE,   // مانع مانند خودرو یا آوار
         BUILDING,   // ساختمان‌ها / غیرقابل عبور
         HOSPITAL,   // نقطه تحویل مجروح
-        EMPTY       // سلول خالی یا تعریف‌نشده
+        EMPTY;      // سلول خالی یا تعریف‌نشده
+
+        /**
+         * آیا این نوع سلول قابل عبور است؟
+         *<p>
+         * در برخی کلاس‌ها نسخه‌های قدیمی متدی با نام {@code walkable()}
+         * فراخوانی می‌شد که وجود نداشت و باعث خطای کامپایل می‌گردید.
+         * برای سازگاری به عقب، هر دو نام {@link #isWalkable()} و
+         * {@link #walkable()} در دسترس هستند.
+         */
+        public boolean isWalkable() {
+            return this == ROAD || this == HOSPITAL;
+        }
+
+        /** سازگاری با کد قدیمی که به جای isWalkable از walkable استفاده می‌کرد. */
+        public boolean walkable() {
+            return isWalkable();
+        }
     }
 
     private final Position position;     // موقعیت سلول در نقشه
@@ -52,7 +69,7 @@ public class Cell {
     public Type getType() { return type; }
 
     public boolean isWalkable() {
-        return type == Type.ROAD || type == Type.HOSPITAL;
+        return type.isWalkable();
     }
 
 

--- a/src/map/MapLoader.java
+++ b/src/map/MapLoader.java
@@ -200,6 +200,14 @@ public final class MapLoader {
         return cityMap;
     }
 
+    /**
+     * Backward-compatible alias for older callers expecting {@code loadMap}.
+     * Simply delegates to {@link #loadTMX(String)}.
+     */
+    public static CityMap loadMap(String tmxPath) throws Exception {
+        return loadTMX(tmxPath);
+    }
+
     private static int parseIntOr(String s, int def) {
         try { return Integer.parseInt(s); } catch (Exception e) { return def; }
     }

--- a/src/map/MapLoader.java
+++ b/src/map/MapLoader.java
@@ -149,9 +149,9 @@ public final class MapLoader {
 
                 // نوع سلول از property ها
 
-                // اگر هیچ property تعریف نشده باشد، فرض را بر جادهٔ قابل عبور می‌گذاریم
-                Cell.Type type = Cell.Type.ROAD; // پیش‌فرض جدید
-                boolean walkable = true;
+                // پیش‌فرض: غیرقابل‌عبور تا زمانی که مشخص شود
+                Cell.Type type = Cell.Type.EMPTY;
+                boolean walkable = false;
 
 
 
@@ -174,7 +174,8 @@ public final class MapLoader {
                                     || "rubble".equalsIgnoreCase(value))     type = Cell.Type.OBSTACLE;
                             else if ("empty".equalsIgnoreCase(value))      type = Cell.Type.EMPTY;
                         } else if (name.equalsIgnoreCase("walkable")) {
-                            walkable = Boolean.parseBoolean(value);
+                            // Tiled ممکن است true/false یا 1/0 خروجی دهد
+                            walkable = "true".equalsIgnoreCase(value) || "1".equals(value);
                         }
                     }
                 }
@@ -183,11 +184,8 @@ public final class MapLoader {
                 // هماهنگ‌سازی نوع سلول با وضعیت walkable
                 if (walkable && type == Cell.Type.EMPTY) {
                     type = Cell.Type.ROAD;
-                } else if (!walkable && type == Cell.Type.ROAD) {
-
-                // اگر مشخصاً غیرقابل عبور باشد ولی نوعی تعیین نشده، آن را مانع فرض کن
-                if (!walkable && (type == Cell.Type.ROAD || type == Cell.Type.EMPTY)) {
-
+                } else if (!walkable && (type == Cell.Type.ROAD || type == Cell.Type.EMPTY)) {
+                    // اگر مشخصاً غیرقابل عبور باشد ولی نوعی تعیین نشده، آن را مانع فرض کن
                     type = Cell.Type.OBSTACLE;
                 }
 


### PR DESCRIPTION
## Summary
- Default TMX loader to treat tiles as obstacles unless marked walkable
- Accept `walkable` property values of `true`/`1` from Tiled
- Expose `Cell.Type` helpers so legacy `walkable()` checks compile

## Testing
- `find src -name "*.java" | xargs javac -d /tmp/build`


------
https://chatgpt.com/codex/tasks/task_e_68b2e55463e0832bbaa61fbaffab2b1c