### PR TITLE
Expose TMX tile properties and guard movement

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -25,10 +25,9 @@ public class Main {
         SwingUtilities.invokeLater(new Runnable() {
             @Override public void run() {
                 try {
-                    // 1) Load map + collision
+                    // 1) Load map + collision directly from TMX properties
                     map = MapLoader.loadTMX("assets/maps/rescue_city.tmx");
-                    collisionMap = CollisionMap.fromMask("assets/maps/Road.png",
-                            map.getTileWidth(), map.getTileHeight());
+                    collisionMap = CollisionMap.fromTMX("assets/maps/rescue_city.tmx");
                     map.setCollisionMap(collisionMap);
 
                     // 2) Spawn rescuer at nearest road (bottom-right search)

--- a/src/map/Cell.java
+++ b/src/map/Cell.java
@@ -13,11 +13,30 @@ import java.awt.image.BufferedImage;
 public class Cell {
 
     public enum Type {
-        ROAD,       // قابل عبور
+        ROAD,       // جاده قابل عبور
+        SIDEWALK,   // پیاده‌رو
+        GROUND,     // زمین خنثی
         OBSTACLE,   // مانع مانند خودرو یا آوار
         BUILDING,   // ساختمان‌ها / غیرقابل عبور
         HOSPITAL,   // نقطه تحویل مجروح
-        EMPTY       // سلول خالی یا تعریف‌نشده
+        EMPTY;      // سلول خالی یا تعریف‌نشده
+
+        /**
+         * آیا این نوع سلول قابل عبور است؟
+         *<p>
+         * در برخی کلاس‌ها نسخه‌های قدیمی متدی با نام {@code walkable()}
+         * فراخوانی می‌شد که وجود نداشت و باعث خطای کامپایل می‌گردید.
+         * برای سازگاری به عقب، هر دو نام {@link #isWalkable()} و
+         * {@link #walkable()} در دسترس هستند.
+         */
+        public boolean isWalkable() {
+            return this == ROAD || this == SIDEWALK || this == HOSPITAL;
+        }
+
+        /** سازگاری با کد قدیمی که به جای isWalkable از walkable استفاده می‌کرد. */
+        public boolean walkable() {
+            return isWalkable();
+        }
     }
 
     private final Position position;     // موقعیت سلول در نقشه
@@ -52,7 +71,7 @@ public class Cell {
     public Type getType() { return type; }
 
     public boolean isWalkable() {
-        return type == Type.ROAD || type == Type.HOSPITAL;
+        return type.isWalkable();
     }
 
 

--- a/src/map/CityMap.java
+++ b/src/map/CityMap.java
@@ -5,6 +5,8 @@ import util.CollisionMap;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 /**
  * --------------------
@@ -21,6 +23,7 @@ public class CityMap {
     private final int tileHeight;  // ارتفاع هر تایل (پیکسل)
     private final Cell[][] grid;   // grid[y][x]
     private CollisionMap collisionMap;   // نگاشت برخورد (اختیاری)
+    private final Map<Integer, Map<String, String>> tileProps = new HashMap<>();
 
     // --- سازنده‌ها ---
     public CityMap(int width, int height) {
@@ -58,6 +61,25 @@ public class CityMap {
     public Cell getCell(Position pos) {
         if (pos == null) return null;
         return getCell(pos.getX(), pos.getY());
+    }
+
+    /** ثبت خصوصیات یک تایل بر اساس GID. */
+    public void registerTileProperties(int gid, Map<String, String> props) {
+        if (props == null) return;
+        tileProps.putIfAbsent(gid, new HashMap<>(props));
+    }
+
+    /** گرفتن شناسهٔ تایل در مختصات مشخص. */
+    public int getTileId(int x, int y) {
+        Cell c = getCell(x, y);
+        return c != null ? c.getTileId() : -1;
+    }
+
+    /** گرفتن property یک تایل با GID و کلید. */
+    public String getTileProperty(int gid, String key) {
+        Map<String, String> p = tileProps.get(gid);
+        if (p == null) return null;
+        return p.get(key);
     }
 
     /** ست‌کردن وضعیت اشغال یک سلول، اگر معتبر باشد. */

--- a/src/map/MoveGuard.java
+++ b/src/map/MoveGuard.java
@@ -1,0 +1,35 @@
+package map;
+
+import util.Position;
+
+/**
+ * بررسی سادهٔ امکان حرکت روی نقشه بر اساس property های تایل.
+ */
+public class MoveGuard {
+
+    private final CityMap map;
+
+    public MoveGuard(CityMap map) {
+        this.map = map;
+    }
+
+    /**
+     * آیا می‌توان به موقعیت موردنظر حرکت کرد؟
+     * شرط: وجود تایل، walkable=true و type یکی از road/sidewalk.
+     */
+    public boolean canMoveTo(Position pos) {
+        if (map == null || pos == null) return false;
+        int x = pos.getX();
+        int y = pos.getY();
+        if (!map.isValid(x, y)) return false;
+
+        int gid = map.getTileId(x, y);
+        if (gid <= 0) return false;
+
+        String walk = map.getTileProperty(gid, "walkable");
+        if (!("true".equalsIgnoreCase(walk) || "1".equals(walk))) return false;
+
+        String type = map.getTileProperty(gid, "type");
+        return "road".equalsIgnoreCase(type) || "sidewalk".equalsIgnoreCase(type);
+    }
+}


### PR DESCRIPTION
## Summary
- Track TMX tile properties in `CityMap` and provide accessors for tile IDs and properties
- Extend loader and `Cell.Type` to recognize sidewalk/ground and keep property maps
- Add `MoveGuard` helper that permits movement only to walkable road/sidewalk tiles

## Testing
- `find src -name "*.java" | xargs javac -d /tmp/build`


------
https://chatgpt.com/codex/tasks/task_e_68b2e55463e0832bbaa61fbaffab2b1c