### PR TITLE
Render injured victims with images

### DIFF
--- a/src/ui/GamePanel.java
+++ b/src/ui/GamePanel.java
@@ -4,6 +4,7 @@ package ui;
 import agent.Rescuer;
 import map.Cell;
 import map.CityMap;
+import util.AssetLoader;
 import util.Position;
 import victim.Injured;
 import victim.InjurySeverity;
@@ -13,7 +14,9 @@ import java.awt.*;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.image.BufferedImage;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * --------------------
@@ -28,6 +31,7 @@ public class GamePanel extends JPanel {
     private CityMap cityMap;
     private List<Rescuer> rescuers;
     private List<Injured> victims;
+    private final Map<InjurySeverity, BufferedImage> victimSprites = new EnumMap<>(InjurySeverity.class);
 
     // ---- تنظیمات نمایش ----
     private int tileSize = 32;             // اندازه‌ی رسم هر تایل روی صفحه
@@ -69,12 +73,25 @@ public class GamePanel extends JPanel {
         requestFocusInWindow();
         setDoubleBuffered(true);
 
+        loadVictimSprites();
+
         addComponentListener(new ComponentAdapter() {
             @Override
             public void componentResized(ComponentEvent e) {
                 updateViewportSize();
             }
         });
+    }
+
+    private void loadVictimSprites() {
+        victimSprites.clear();
+        for (InjurySeverity sev : InjurySeverity.values()) {
+            String path = "assets/characters/" + sev.name() + ".png";
+            BufferedImage img = AssetLoader.loadScaled(path, tileSize, tileSize);
+            if (img != null) {
+                victimSprites.put(sev, img);
+            }
+        }
     }
 
     // ---------------------- رندر اصلی ----------------------
@@ -179,17 +196,24 @@ public class GamePanel extends JPanel {
             if (p.getX() < viewX || p.getX() >= viewX + viewWidth ||
                     p.getY() < viewY || p.getY() >= viewY + viewHeight) continue;
 
-            Color col;
-            InjurySeverity sev = inj.getSeverity();
-            if (sev == InjurySeverity.LOW) col = Color.YELLOW;
-            else if (sev == InjurySeverity.MEDIUM) col = Color.ORANGE;
-            else col = Color.RED; // CRITICAL
+            BufferedImage sprite = victimSprites.get(inj.getSeverity());
+            if (sprite != null) {
+                int drawX = p.getX() * tileSize + (tileSize - sprite.getWidth()) / 2;
+                int drawY = p.getY() * tileSize + (tileSize - sprite.getHeight());
+                g.drawImage(sprite, drawX, drawY, null);
+            } else {
+                Color col;
+                InjurySeverity sev = inj.getSeverity();
+                if (sev == InjurySeverity.LOW) col = Color.YELLOW;
+                else if (sev == InjurySeverity.MEDIUM) col = Color.ORANGE;
+                else col = Color.RED; // CRITICAL
 
-            g.setColor(col);
-            int r = tileSize / 2;
-            int cx = p.getX() * tileSize + (tileSize - r) / 2;
-            int cy = p.getY() * tileSize + (tileSize - r) / 2;
-            g.fillOval(cx, cy, r, r);
+                g.setColor(col);
+                int r = tileSize / 2;
+                int cx = p.getX() * tileSize + (tileSize - r) / 2;
+                int cy = p.getY() * tileSize + (tileSize - r) / 2;
+                g.fillOval(cx, cy, r, r);
+            }
         }
     }
 
@@ -274,6 +298,7 @@ public class GamePanel extends JPanel {
             setPreferredSize(new Dimension(viewWidth * tileSize,
                     viewHeight * tileSize));
         }
+        loadVictimSprites();
         revalidate();
         repaint();
     }


### PR DESCRIPTION
## Summary
- load injured victim images for each severity
- draw victim sprites instead of colored circles
- load victim sprites dynamically from severity enum

## Testing
- `find src -name "*.java" | xargs javac -d out`


------
https://chatgpt.com/codex/tasks/task_e_68b5439c2a0c832b853faac2db055600