### PR TITLE
Implement rescue reward scoring

### DIFF
--- a/src/controller/ScoreManager.java
+++ b/src/controller/ScoreManager.java
@@ -7,6 +7,7 @@ import victim.InjurySeverity;
  * مدیریت امتیاز بازی (جهانی/Static).
  * - امتیاز شروع: 500
  * - جریمه مرگ: 2 × زمان اولیه تایمر مجروح
+ * - پاداش نجات: 2 × زمان اولیه تایمر مجروح
  * - (اختیاری) پاداش نجات بر اساس شدت
  *
  * نکته: همه‌ی متدها روی یک "score" سراسری کار می‌کنند؛
@@ -48,6 +49,20 @@ public final class ScoreManager {
         score -= (2 * initial);
     }
 
+    /** پاداش نجات بر اساس زمان اولیه (ثانیه/تیک) */
+    public static synchronized void applyRescueRewardByInitialTime(int initialSeconds) {
+        if (initialSeconds < 0) initialSeconds = 0;
+        score += (2 * initialSeconds);
+    }
+
+    /** نسخه راحت با خود آبجکت مجروح */
+    public static synchronized void applyRescueReward(Injured injured) {
+        if (injured == null) return;
+        int initial = injured.getInitialTimeLimit();
+        if (initial < 0) initial = 0;
+        score += (2 * initial);
+    }
+
     /** (اختیاری) پاداش نجات */
     public static synchronized void addRescueRewardBySeverity(InjurySeverity severity) {
         int reward = 0;
@@ -65,5 +80,7 @@ public final class ScoreManager {
     public synchronized void deductInstance(int amount) { deduct(amount); }
     public synchronized void applyDeathPenaltyByInitialTimeInstance(int s){ applyDeathPenaltyByInitialTime(s); }
     public synchronized void applyDeathPenaltyInstance(Injured injured){ applyDeathPenalty(injured); }
+    public synchronized void applyRescueRewardByInitialTimeInstance(int s){ applyRescueRewardByInitialTime(s); }
+    public synchronized void applyRescueRewardInstance(Injured injured){ applyRescueReward(injured); }
     public synchronized void addRescueRewardBySeverityInstance(InjurySeverity sev){ addRescueRewardBySeverity(sev); }
 }

--- a/src/victim/VictimManager.java
+++ b/src/victim/VictimManager.java
@@ -83,13 +83,12 @@ public class VictimManager {
         }
     }
 
-    /** اعلام نجات یک مجروح: وضعیت نجات + (اختیاری) پاداش */
+    /** اعلام نجات یک مجروح: وضعیت نجات + پاداش امتیاز */
     public void onVictimRescued(Injured injured) {
         if (injured == null) return;
         if (!injured.isDead() && !injured.isRescued()) {
             injured.markAsRescued();
-            // اگر پاداش لازم داری، این خط را باز کن:
-            // ScoreManager.addRescueRewardBySeverity(injured.getSeverity());
+            ScoreManager.applyRescueReward(injured); // +2×زمان اولیه
         }
     }
 }


### PR DESCRIPTION
## Summary
- Extend `ScoreManager` to award twice the victim's initial timer when rescued
- Trigger rescue reward in `VictimManager` upon marking victims as rescued

## Testing
- `javac -d out $(find src -name "*.java")`

------
https://chatgpt.com/codex/tasks/task_e_68b6947ad6dc832b9f5de30c84aae9c1