### PR TITLE
Add AI rescuer spawn and control

### DIFF
--- a/src/agent/AgentController.java
+++ b/src/agent/AgentController.java
@@ -97,7 +97,7 @@ public class AgentController {
         // --- حالت عادی: به سمت مجروح قابل نجات برو ---
         if (candidates == null || candidates.isEmpty()) return;
 
-        Injured target = chooseNearestRescuable(rescuer.getPosition(), candidates);
+        Injured target = chooseLeastTime(rescuer.getPosition(), candidates);
         if (target == null) return;
 
         // اگر مجاور است → Pickup و ورود به آمبولانس
@@ -155,17 +155,20 @@ public class AgentController {
 
     /* === انتخاب هدف‌ها === */
 
-    private Injured chooseNearestRescuable(Position from, List<Injured> list) {
+    private Injured chooseLeastTime(Position from, List<Injured> list) {
         if (list == null || list.isEmpty()) return null;
         Injured best = null;
-        int bestD = Integer.MAX_VALUE;
+        int bestTime = Integer.MAX_VALUE;
+        int bestDist = Integer.MAX_VALUE;
         for (int i = 0; i < list.size(); i++) {
             Injured inj = list.get(i);
             if (inj == null) continue;
             if (inj.isDead() || inj.isRescued() || inj.getPosition() == null) continue;
+            int rem = inj.getRemainingTime();
             int d = manhattan(from, inj.getPosition());
-            if (d < bestD) {
-                bestD = d;
+            if (rem < bestTime || (rem == bestTime && d < bestDist)) {
+                bestTime = rem;
+                bestDist = d;
                 best = inj;
             }
         }

--- a/src/agent/Rescuer.java
+++ b/src/agent/Rescuer.java
@@ -36,6 +36,8 @@ public class Rescuer {
     private boolean isBusy;
     private Injured carryingVictim;
     private boolean ambulanceMode;
+    /** اگر true باشد، این نجات‌دهنده توسط هوش مصنوعی کنترل می‌شود */
+    private boolean aiControlled;
 
     /** اگر true باشد، نجات‌دهنده می‌تواند روی هر سلولی حرکت کند (نادیده گرفتن collision/occupied/hospital) */
     private boolean noClip = true; // فقط روی Rescuer اثر دارد؛ آمبولانس را تغییر نمی‌دهد
@@ -68,6 +70,7 @@ public class Rescuer {
         this.isBusy = false;
         this.carryingVictim = null;
         this.ambulanceMode = false;
+        this.aiControlled = false;
         loadRescuerSpriteSheet();
         loadAmbulanceSpriteSheet();
     }
@@ -267,6 +270,10 @@ public class Rescuer {
     /** فلگ no-clip فقط برای حرکتِ خود Rescuer (نه Vehicle). */
     public boolean isNoClip() { return noClip; }
     public void setNoClip(boolean noClip) { this.noClip = noClip; }
+
+    /** وضعیت کنترل هوش مصنوعی */
+    public boolean isAIControlled() { return aiControlled; }
+    public void setAIControlled(boolean aiControlled) { this.aiControlled = aiControlled; }
 
     // ====== عملیات حمل/تحویل ======
     public void enterAmbulanceModeWith(Injured victim) {

--- a/src/controller/GameEngine.java
+++ b/src/controller/GameEngine.java
@@ -115,6 +115,53 @@ public class GameEngine {
         this.keyHandler = handler;
     }
 
+    // --- اسپاون نجات‌دهندهٔ هوش مصنوعی از HUD ---
+    public void spawnAIRescuer() {
+        CityMap map = state.getMap();
+        List<Rescuer> rescuerList = state.getRescuers();
+        if (map == null || rescuerList == null) return;
+
+        Position spawn = findSpawnTile(map, rescuerList);
+        int newId = agentManager.size() + 1;
+        Rescuer ai = new Rescuer(newId, spawn);
+        ai.setAIControlled(true);
+        rescuerList.add(ai);
+        agentManager.addRescuer(ai);
+        map.setOccupied(spawn.getX(), spawn.getY(), true);
+        prevAmbulanceState.put(ai.getId(), Boolean.FALSE);
+
+        if (miniMapPanel != null) {
+            miniMapPanel.updateMiniMap(map, rescuerList, state.getVictims());
+        }
+        if (gamePanel != null) gamePanel.repaint();
+        if (hudPanel != null) hudPanel.repaint();
+
+        start();
+    }
+
+    private Position findSpawnTile(CityMap map, List<Rescuer> rescuers) {
+        if (rescuers != null && !rescuers.isEmpty()) {
+            Position base = rescuers.get(0).getPosition();
+            int[] dx = {0, 1, 0, -1};
+            int[] dy = {1, 0, -1, 0};
+            for (int i = 0; i < dx.length; i++) {
+                int nx = base.getX() + dx[i];
+                int ny = base.getY() + dy[i];
+                if (map.isValid(nx, ny) && map.isRoad(nx, ny) && map.isWalkable(nx, ny)) {
+                    return new Position(nx, ny);
+                }
+            }
+        }
+        for (int y = 0; y < map.getHeight(); y++) {
+            for (int x = 0; x < map.getWidth(); x++) {
+                if (map.isRoad(x, y) && map.isWalkable(x, y)) {
+                    return new Position(x, y);
+                }
+            }
+        }
+        return new Position(0, 0);
+    }
+
     // ------------------------------
     // کنترل حلقه
     // ------------------------------

--- a/src/controller/RescueCoordinator.java
+++ b/src/controller/RescueCoordinator.java
@@ -55,6 +55,7 @@ public class RescueCoordinator {
     public void executeRescueCycle() {
         Collection<Rescuer> rescuers = agentManager.getAllRescuers();
         for (Rescuer r : rescuers) {
+            if (r == null || !r.isAIControlled()) continue;
             List<Injured> candidates = victimManager.getRescuableVictims();
             agentController.performAction(r, candidates, hospitals);
         }

--- a/src/ui/HUDPanel.java
+++ b/src/ui/HUDPanel.java
@@ -45,6 +45,7 @@ public class HUDPanel extends JPanel {
     private final JButton btnSave;
     private final JButton btnLoad;
     private final JButton btnRestart;
+    private final JButton btnAddAI;
 
     // ------------------- سازنده‌ها -------------------
     public HUDPanel() {
@@ -73,6 +74,7 @@ public class HUDPanel extends JPanel {
         btnSave    = createIconButton("assets/ui/save.png",    "Quick Save", "Save");
         btnLoad    = createIconButton("assets/ui/load.png",    "Quick Load", "Load");
         btnRestart = createIconButton("assets/ui/restart.png", "Restart",    "Restart");
+        btnAddAI   = createIconButton("assets/ui/escape.png",  "Add AI",     "AI");
         wireNonPauseButtons();
         addButtonsToBar();
     }
@@ -104,6 +106,7 @@ public class HUDPanel extends JPanel {
         btnSave    = createIconButton("assets/ui/save.png",    "Quick Save", "Save");
         btnLoad    = createIconButton("assets/ui/load.png",    "Quick Load", "Load");
         btnRestart = createIconButton("assets/ui/restart.png", "Restart",    "Restart");
+        btnAddAI   = createIconButton("assets/ui/escape.png",  "Add AI",     "AI");
         wireNonPauseButtons();
         addButtonsToBar();
     }
@@ -179,6 +182,7 @@ public class HUDPanel extends JPanel {
         controlBar.add(btnSave);
         controlBar.add(btnLoad);
         controlBar.add(btnRestart);
+        controlBar.add(btnAddAI);
         controlBar.revalidate();
         controlBar.repaint();
     }
@@ -230,6 +234,13 @@ public class HUDPanel extends JPanel {
                 if (gameEngine == null) { System.out.println("[HUDPanel] Restart clicked BUT gameEngine==null"); return; }
                 System.out.println("[HUDPanel] Restart → restartGame()");
                 try { gameEngine.restartGame(); } catch (Throwable t) { t.printStackTrace(); }
+            }
+        });
+        btnAddAI.addActionListener(new ActionListener() {
+            @Override public void actionPerformed(ActionEvent e) {
+                if (gameEngine == null) { System.out.println("[HUDPanel] AddAI clicked BUT gameEngine==null"); return; }
+                System.out.println("[HUDPanel] AddAI → spawnAIRescuer()");
+                try { gameEngine.spawnAIRescuer(); } catch (Throwable t) { t.printStackTrace(); }
             }
         });
     }


### PR DESCRIPTION
## Summary
- Add HUD button to spawn AI rescuer on demand
- Prioritize victims by remaining time for AI
- Run rescue cycle only for AI-controlled rescuers

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_68b8560134b4832bbf923e33e719f5fe