### PR TITLE
Add AI rescuer spawn and control

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -99,7 +99,7 @@ public class Main {
                     for (Rescuer r : rescuers) { agentManager.addRescuer(r); }
                     VictimManager victimManager = new VictimManager();
                     for (Injured v : victims) { victimManager.addInjured(v); }
-                    List<Hospital> hospitals = new ArrayList<Hospital>();
+                    List<Hospital> hospitals = scanHospitalsFromMask(cityMap);
                     RescueCoordinator rescueCoordinator = new RescueCoordinator(
                             agentManager,
                             victimManager,
@@ -355,6 +355,23 @@ public class Main {
             for (int x = 0; x < a[y].length; x++)
                 if (a[y][x]) c++;
         return c;
+    }
+
+    /** تایل‌های HospitalMask را به لیست Hospital تبدیل می‌کند. */
+    private static List<Hospital> scanHospitalsFromMask(CityMap map) {
+        List<Hospital> out = new ArrayList<Hospital>();
+        if (map == null) return out;
+        int w = map.getWidth();
+        int h = map.getHeight();
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                if (map.isHospitalMask(x, y)) {
+                    out.add(new Hospital(new Position(x, y)));
+                }
+            }
+        }
+        System.out.println("[HospitalScanner] found " + out.size() + " hospitals from mask.");
+        return out;
     }
 
     /** --- اسپاون مجروح روی آوار/خودروهای خراب (OBSTACLE) --- */

--- a/src/agent/AgentController.java
+++ b/src/agent/AgentController.java
@@ -97,7 +97,7 @@ public class AgentController {
         // --- حالت عادی: به سمت مجروح قابل نجات برو ---
         if (candidates == null || candidates.isEmpty()) return;
 
-        Injured target = chooseNearestRescuable(rescuer.getPosition(), candidates);
+        Injured target = chooseLeastTime(rescuer.getPosition(), candidates);
         if (target == null) return;
 
         // اگر مجاور است → Pickup و ورود به آمبولانس
@@ -155,17 +155,20 @@ public class AgentController {
 
     /* === انتخاب هدف‌ها === */
 
-    private Injured chooseNearestRescuable(Position from, List<Injured> list) {
+    private Injured chooseLeastTime(Position from, List<Injured> list) {
         if (list == null || list.isEmpty()) return null;
         Injured best = null;
-        int bestD = Integer.MAX_VALUE;
+        int bestTime = Integer.MAX_VALUE;
+        int bestDist = Integer.MAX_VALUE;
         for (int i = 0; i < list.size(); i++) {
             Injured inj = list.get(i);
             if (inj == null) continue;
             if (inj.isDead() || inj.isRescued() || inj.getPosition() == null) continue;
+            int rem = inj.getRemainingTime();
             int d = manhattan(from, inj.getPosition());
-            if (d < bestD) {
-                bestD = d;
+            if (rem < bestTime || (rem == bestTime && d < bestDist)) {
+                bestTime = rem;
+                bestDist = d;
                 best = inj;
             }
         }

--- a/src/agent/Rescuer.java
+++ b/src/agent/Rescuer.java
@@ -36,6 +36,8 @@ public class Rescuer {
     private boolean isBusy;
     private Injured carryingVictim;
     private boolean ambulanceMode;
+    /** اگر true باشد، این نجات‌دهنده توسط هوش مصنوعی کنترل می‌شود */
+    private boolean aiControlled;
 
     /** اگر true باشد، نجات‌دهنده می‌تواند روی هر سلولی حرکت کند (نادیده گرفتن collision/occupied/hospital) */
     private boolean noClip = true; // فقط روی Rescuer اثر دارد؛ آمبولانس را تغییر نمی‌دهد
@@ -68,6 +70,7 @@ public class Rescuer {
         this.isBusy = false;
         this.carryingVictim = null;
         this.ambulanceMode = false;
+        this.aiControlled = false;
         loadRescuerSpriteSheet();
         loadAmbulanceSpriteSheet();
     }
@@ -267,6 +270,10 @@ public class Rescuer {
     /** فلگ no-clip فقط برای حرکتِ خود Rescuer (نه Vehicle). */
     public boolean isNoClip() { return noClip; }
     public void setNoClip(boolean noClip) { this.noClip = noClip; }
+
+    /** وضعیت کنترل هوش مصنوعی */
+    public boolean isAIControlled() { return aiControlled; }
+    public void setAIControlled(boolean aiControlled) { this.aiControlled = aiControlled; }
 
     // ====== عملیات حمل/تحویل ======
     public void enterAmbulanceModeWith(Injured victim) {

--- a/src/controller/GameEngine.java
+++ b/src/controller/GameEngine.java
@@ -115,6 +115,59 @@ public class GameEngine {
         this.keyHandler = handler;
     }
 
+    // --- اسپاون نجات‌دهندهٔ هوش مصنوعی از HUD ---
+    public void spawnAIRescuer() {
+        CityMap map = state.getMap();
+        List<Rescuer> rescuerList = state.getRescuers();
+        if (map == null || rescuerList == null) return;
+
+        Position spawn = findSpawnTile(map, rescuerList);
+        int newId = agentManager.size() + 1;
+        Rescuer ai = new Rescuer(newId, spawn);
+        ai.setAIControlled(true);
+        rescuerList.add(ai);
+        agentManager.addRescuer(ai);
+        map.setOccupied(spawn.getX(), spawn.getY(), true);
+        prevAmbulanceState.put(ai.getId(), Boolean.FALSE);
+
+        if (miniMapPanel != null) {
+            miniMapPanel.updateMiniMap(map, rescuerList, state.getVictims());
+        }
+        if (gamePanel != null) {
+            gamePanel.updateData(map, rescuerList, state.getVictims());
+        }
+        if (hudPanel != null) hudPanel.updateHUD(
+                ScoreManager.getScore(),
+                (int) victimManager.countRescued(),
+                (int) victimManager.countDead()
+        );
+
+        start();
+    }
+
+    private Position findSpawnTile(CityMap map, List<Rescuer> rescuers) {
+        if (rescuers != null && !rescuers.isEmpty()) {
+            Position base = rescuers.get(0).getPosition();
+            int[] dx = {0, 1, 0, -1};
+            int[] dy = {1, 0, -1, 0};
+            for (int i = 0; i < dx.length; i++) {
+                int nx = base.getX() + dx[i];
+                int ny = base.getY() + dy[i];
+                if (map.isValid(nx, ny) && map.isRoad(nx, ny) && map.isWalkable(nx, ny)) {
+                    return new Position(nx, ny);
+                }
+            }
+        }
+        for (int y = 0; y < map.getHeight(); y++) {
+            for (int x = 0; x < map.getWidth(); x++) {
+                if (map.isRoad(x, y) && map.isWalkable(x, y)) {
+                    return new Position(x, y);
+                }
+            }
+        }
+        return new Position(0, 0);
+    }
+
     // ------------------------------
     // کنترل حلقه
     // ------------------------------

--- a/src/controller/RescueCoordinator.java
+++ b/src/controller/RescueCoordinator.java
@@ -55,6 +55,7 @@ public class RescueCoordinator {
     public void executeRescueCycle() {
         Collection<Rescuer> rescuers = agentManager.getAllRescuers();
         for (Rescuer r : rescuers) {
+            if (r == null || !r.isAIControlled()) continue;
             List<Injured> candidates = victimManager.getRescuableVictims();
             agentController.performAction(r, candidates, hospitals);
         }

--- a/src/ui/HUDPanel.java
+++ b/src/ui/HUDPanel.java
@@ -10,6 +10,7 @@ import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.net.URL;
 import java.util.List;
@@ -45,6 +46,7 @@ public class HUDPanel extends JPanel {
     private final JButton btnSave;
     private final JButton btnLoad;
     private final JButton btnRestart;
+    private final JButton btnAddAI;
 
     // ------------------- سازنده‌ها -------------------
     public HUDPanel() {
@@ -73,6 +75,8 @@ public class HUDPanel extends JPanel {
         btnSave    = createIconButton("assets/ui/save.png",    "Quick Save", "Save");
         btnLoad    = createIconButton("assets/ui/load.png",    "Quick Load", "Load");
         btnRestart = createIconButton("assets/ui/restart.png", "Restart",    "Restart");
+        btnAddAI   = createIconButton("assets/ui/escape.png",  "Add AI",     "AI");
+        ensureAddAIIcon();
         wireNonPauseButtons();
         addButtonsToBar();
     }
@@ -104,6 +108,8 @@ public class HUDPanel extends JPanel {
         btnSave    = createIconButton("assets/ui/save.png",    "Quick Save", "Save");
         btnLoad    = createIconButton("assets/ui/load.png",    "Quick Load", "Load");
         btnRestart = createIconButton("assets/ui/restart.png", "Restart",    "Restart");
+        btnAddAI   = createIconButton("assets/ui/escape.png",  "Add AI",     "AI");
+        ensureAddAIIcon();
         wireNonPauseButtons();
         addButtonsToBar();
     }
@@ -179,6 +185,7 @@ public class HUDPanel extends JPanel {
         controlBar.add(btnSave);
         controlBar.add(btnLoad);
         controlBar.add(btnRestart);
+        controlBar.add(btnAddAI);
         controlBar.revalidate();
         controlBar.repaint();
     }
@@ -232,6 +239,36 @@ public class HUDPanel extends JPanel {
                 try { gameEngine.restartGame(); } catch (Throwable t) { t.printStackTrace(); }
             }
         });
+        btnAddAI.addActionListener(new ActionListener() {
+            @Override public void actionPerformed(ActionEvent e) {
+                if (gameEngine == null) { System.out.println("[HUDPanel] AddAI clicked BUT gameEngine==null"); return; }
+                System.out.println("[HUDPanel] AddAI → spawnAIRescuer()");
+                try { gameEngine.spawnAIRescuer(); } catch (Throwable t) { t.printStackTrace(); }
+            }
+        });
+    }
+
+    /** اطمینان از اینکه دکمه AI همیشه یک آیکن دارد */
+    private void ensureAddAIIcon() {
+        if (btnAddAI.getIcon() == null) {
+            btnAddAI.setIcon(buildAddIcon());
+            btnAddAI.setText("");
+        }
+    }
+
+    /** آیکن پلاس سبز ساده برای افزودن نجات‌گر AI */
+    private Icon buildAddIcon() {
+        int size = 24;
+        BufferedImage img = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = img.createGraphics();
+        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        g.setColor(new Color(40, 200, 40));
+        g.setStroke(new BasicStroke(4f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+        int mid = size / 2;
+        g.drawLine(mid, 4, mid, size - 4);
+        g.drawLine(4, mid, size - 4, mid);
+        g.dispose();
+        return new ImageIcon(img);
     }
 
     // ------------------- هِلپر ساخت دکمه آیکن‌دار -------------------


### PR DESCRIPTION
## Summary
- Add HUD button to spawn AI rescuer on demand
- Prioritize victims by remaining time for AI
- Run rescue cycle only for AI-controlled rescuers
- Refresh map and HUD immediately after AI spawn
- Scan hospital mask on startup to populate hospital list for ambulance delivery
- Always show a plus icon for the Add-AI button even when no image asset is found

## Testing
- `find src -name '*.java' > sources.txt`
- `javac @sources.txt`


------
https://chatgpt.com/codex/tasks/task_e_68b8560134b4832bbf923e33e719f5fe