### PR TITLE
Fix rescuer left movement and adjust timer

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -87,7 +87,7 @@ public class Main {
 
                     // امتیاز اولیه + HUD با MiniMap
                     ScoreManager.resetToDefault();
-                    final int[] timeLeft = new int[]{300}; // ۵ دقیقه شروع
+                    final int[] timeLeft = new int[]{180}; // ۳ دقیقه شروع
                     final HUDPanel hud = new HUDPanel(cityMap, rescuers, victims);
                     hud.updateHUD(ScoreManager.getScore(), rescuedCount, deadCount, timeLeft[0],
                             cityMap, rescuers, victims);

--- a/src/agent/Rescuer.java
+++ b/src/agent/Rescuer.java
@@ -118,8 +118,9 @@ public class Rescuer {
             }
         }
 
+        boolean hadLeftRow = rescuerFrames[DIR_LEFT] != null && rescuerFrames[DIR_LEFT][0] != null;
         // اگر ردیف LEFT موجود نبود، از RIGHT وارونه بساز
-        if ((rescuerFrames[DIR_LEFT] == null || rescuerFrames[DIR_LEFT][0] == null) && rescuerFrames[DIR_RIGHT] != null) {
+        if (!hadLeftRow && rescuerFrames[DIR_RIGHT] != null && rescuerFrames[DIR_RIGHT][0] != null) {
             BufferedImage[] leftRow = new BufferedImage[RESCUER_COLS];
             for (int c = 0; c < RESCUER_COLS; c++) {
                 if (rescuerFrames[DIR_RIGHT][c] != null) {
@@ -127,6 +128,14 @@ public class Rescuer {
                 }
             }
             rescuerFrames[DIR_LEFT] = leftRow;
+        }
+
+        // در برخی شیت‌ها ترتیب ردیف‌ها برعکس است (DOWN,RIGHT,LEFT)
+        final boolean SWAP_LR = true;
+        if (SWAP_LR && hadLeftRow && rescuerFrames[DIR_RIGHT] != null) {
+            BufferedImage[] tmp = rescuerFrames[DIR_LEFT];
+            rescuerFrames[DIR_LEFT] = rescuerFrames[DIR_RIGHT];
+            rescuerFrames[DIR_RIGHT] = tmp;
         }
 
         // اگر ردیف UP نبود، از DOWN کپی کن


### PR DESCRIPTION
## Summary
- swap rescuer sprite rows to correct leftward animation
- start HUD timer with three minutes instead of five

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_68b8b56e7c4c832b85670a678bb684f6