### PR TITLE
Persist timer and align HUD with game panel

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -87,9 +87,9 @@ public class Main {
 
                     // امتیاز اولیه + HUD با MiniMap
                     ScoreManager.resetToDefault();
-                    final int[] timeLeft = new int[]{180}; // ۳ دقیقه شروع
                     final HUDPanel hud = new HUDPanel(cityMap, rescuers, victims);
-                    hud.updateHUD(ScoreManager.getScore(), rescuedCount, deadCount, timeLeft[0],
+                    hud.setTimeLeft(180); // ۳ دقیقه شروع
+                    hud.updateHUD(ScoreManager.getScore(), rescuedCount, deadCount, hud.getTimeLeft(),
                             cityMap, rescuers, victims);
 
                     // 5.1) راه‌اندازی موتور بازی برای امکانات Save/Load
@@ -171,8 +171,9 @@ public class Main {
                                     SwingUtilities.invokeLater(new Runnable() {
                                         @Override public void run() {
                                             // کم کردن زمان
-                                            if (timeLeft[0] > 0) {
-                                                timeLeft[0]--;
+                                            int t = hud.getTimeLeft();
+                                            if (t > 0) {
+                                                hud.setTimeLeft(t - 1);
                                             }
 
                                             // تیک تایمر و تشخیص مرگ‌ها
@@ -197,7 +198,7 @@ public class Main {
                                             rescuedCount = resc;
 
                                             // HUD با مینی‌مپ آپدیت میشه
-                                            hud.updateHUD(ScoreManager.getScore(), rescuedCount, deadCount, timeLeft[0],
+                                            hud.updateHUD(ScoreManager.getScore(), rescuedCount, deadCount, hud.getTimeLeft(),
                                                     cityMap, rescuers, victims);
                                             panel.repaint();
                                         }

--- a/src/controller/GameEngine.java
+++ b/src/controller/GameEngine.java
@@ -377,6 +377,12 @@ public class GameEngine {
             } catch (Throwable ignored) {}
         }
 
+        // --- زمان باقی‌مانده بازی ---
+        if (hudPanel != null) {
+            try { hudPanel.setTimeLeft((int) (loaded.getRemainingMillis() / 1000L)); }
+            catch (Throwable ignored) {}
+        }
+
         // --- بازسازی قربانی‌ها از DTO ---
         Map<Integer, Injured> victimMap = new HashMap<Integer, Injured>();
         List<Injured> newVictims = new ArrayList<Injured>();
@@ -518,6 +524,13 @@ public class GameEngine {
                         map.getTileWidth(), map.getTileHeight()
                 );
             } catch (Throwable ignored) {}
+        }
+
+        // زمان باقی‌مانده بازی (بر حسب میلی‌ثانیه)
+        if (hudPanel != null) {
+            try {
+                snap.setRemainingMillis((long) hudPanel.getTimeLeft() * 1000L);
+            } catch (Throwable ignored) { }
         }
 
         // Rescuers

--- a/src/ui/HUDPanel.java
+++ b/src/ui/HUDPanel.java
@@ -69,7 +69,8 @@ public class HUDPanel extends JPanel {
         setLayout(new BorderLayout());
         setBackground(BG);
         setForeground(FG);
-        setBorder(new EmptyBorder(HUD_GUTTER_PX, HUD_GUTTER_PX, HUD_GUTTER_PX, HUD_GUTTER_PX));
+        // فاصله‌ی کناری چپ را صفر می‌کنیم تا پنل بازی به HUD بچسبد
+        setBorder(new EmptyBorder(HUD_GUTTER_PX, 0, HUD_GUTTER_PX, HUD_GUTTER_PX));
 
         score = rescuedCount = deadCount = 0;
         timeLeft = 0;
@@ -168,6 +169,13 @@ public class HUDPanel extends JPanel {
     public void setTimeLeft(int seconds) {
         this.timeLeft = seconds < 0 ? 0 : seconds;
         repaint();
+    }
+
+    /**
+     * مقدار فعلی زمان باقی‌مانده را برمی‌گرداند (بر حسب ثانیه).
+     */
+    public int getTimeLeft() {
+        return timeLeft;
     }
 
     /** سنکرون‌سازی Pause از بیرون (مثلاً بعد از Resume/Restart) */


### PR DESCRIPTION
## Summary
- Remove left gutter from HUD so the game and HUD panels sit flush
- Expose HUD remaining-time accessor and save time in GameState
- Restore timer on load/restart and drive countdown directly from HUD

## Testing
- `javac -d bin $(find src -name '*.java')`


------
https://chatgpt.com/codex/tasks/task_e_68b8db46f6c0832bbc7f83812ed1dcf4